### PR TITLE
Location means cancelled.

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,6 +13,7 @@
     "device": ""
   },
   "remove_cancelled_classes": true,
+  "location_means_cancelled": [""],
   "blacklist": ["", "KWT"],
   "reminders": [
     { "method": "popup", "minutes": "5" }


### PR DESCRIPTION
Added a new feature.

Some schools change the location of an appointment to a certain value
instead of canceling the appointment. This new feature checks if the new
location might be that special value and recognises it's cancelled
rather than changed location.

Let's hope it works.